### PR TITLE
[bug] non modular routes not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All Notable changes to `route-generator-plugin` will be documented in this file
 
+## v0.0.2
+
+- Fix test with missing array key
+
 ## v.0.0.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All Notable changes to `route-generator-plugin` will be documented in this file
 ## v0.0.2
 
 - Fix test with missing array key
+- Fix issue with non modular route configuration
 
 ## v.0.0.1
 

--- a/src/RouteGenerator.php
+++ b/src/RouteGenerator.php
@@ -99,6 +99,12 @@ final class RouteGenerator
      */
     private function findRoute($alias)
     {
+        // If we have a non modular configuration, check if the key exists
+        if (array_key_exists($alias, $this->routes)) {
+            return $this->routes[$alias];
+        }
+
+        // If we have a modular configuration, check if the key exists
         foreach($this->routes as $modules) {
             if (array_key_exists($alias, $modules)) {
                 return $modules[$alias];

--- a/tests/RouteGeneratorTest.php
+++ b/tests/RouteGeneratorTest.php
@@ -77,6 +77,7 @@ class RouteGeneratorTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Route\Generator\RouteGenerator::__construct
      * @covers Route\Generator\RouteGenerator::generate
+     * @covers Route\Generator\RouteGenerator::findRoute
      */
     public function test_static_route_has_been_generated_correctly()
     {
@@ -107,6 +108,11 @@ class RouteGeneratorTest extends PHPUnit_Framework_TestCase
         $generator->generate('hello_person', ['id' => 1]);
     }
 
+    /**
+     * @covers Route\Generator\RouteGenerator::__construct
+     * @covers Route\Generator\RouteGenerator::generate
+     * @covers Route\Generator\RouteGenerator::findRoute
+     */
     public function test_dynamic_route_with_correct_parameters()
     {
         $generator = new RouteGenerator($this->config);
@@ -117,6 +123,7 @@ class RouteGeneratorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Route\Generator\RouteGenerator::__construct
      * @covers Route\Generator\RouteGenerator::generate
      * @covers Route\Generator\RouteGenerator::findRoute
      */

--- a/tests/RouteGeneratorTest.php
+++ b/tests/RouteGeneratorTest.php
@@ -116,6 +116,19 @@ class RouteGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('/hello/Timmy+Mallet', $route);
     }
 
+    /**
+     * @covers Route\Generator\RouteGenerator::generate
+     * @covers Route\Generator\RouteGenerator::findRoute
+     */
+    public function test_route_is_found_without_existing_in_a_module()
+    {
+        $generator = new RouteGenerator($this->config['hello_module']);
+
+        $route = $generator->generate('hello_world');
+
+        $this->assertEquals('/hello/world', $route);
+    }
+
     public function tearDown()
     {
         $this->config

--- a/tests/RouteGeneratorTest.php
+++ b/tests/RouteGeneratorTest.php
@@ -34,7 +34,8 @@ class RouteGeneratorTest extends PHPUnit_Framework_TestCase
                     'pattern'    => '/hello/{name}',
                     'controller' => function($name) {
                         echo 'Hello '.$name;
-                    }
+                    },
+                    'method'     => ['GET'],
                 ],
             ],
         ];


### PR DESCRIPTION
Adds the ability to have 2 types of route configs to be passed.

``` php
$nonModularRoutes = [
    'route_alias' => [
        'pattern' => '...',
        'controller' => '...',
        'method' => '...',
    ],
];

$modularRoutes = [
    'module_alias' => [
        'route_alias' => [
            'pattern' => '...',
            'controller' => '...',
            'method' => '...',
        ],
    ],
];
```

Also add missing 'method' key in test and `@covers` to test methods
